### PR TITLE
:add:ツイートの削除機能の追加

### DIFF
--- a/twitter/app/Http/Controllers/TweetController.php
+++ b/twitter/app/Http/Controllers/TweetController.php
@@ -29,7 +29,7 @@ class TweetController extends Controller
      */
     public function showTweetForm(): view
     {
-        return view('tweet.create');
+        return view("tweet.create");
     }
 
     /**
@@ -42,10 +42,10 @@ class TweetController extends Controller
     public function create(TweetRequest $request): RedirectResponse
     {
         $authorId = Auth::id();
-        $content = $request->input('content');
+        $content = $request->input("content");
         $this->tweet->create($authorId, $content);
 
-        return redirect()->route('tweets.show');
+        return redirect()->route("tweets.show");
     }
 
     /**
@@ -57,7 +57,7 @@ class TweetController extends Controller
     {
         $tweets = $this->tweet->getAllTweets();
 
-        return view('top.index', compact('tweets'));
+        return view("top.index", compact("tweets"));
     }
 
     /**
@@ -71,7 +71,7 @@ class TweetController extends Controller
     {
         $tweet = $this->tweet->getTweet($userId);
 
-        return view('tweet.show', compact('tweet'));
+        return view("tweet.show", compact('tweet'));
     }
 
     /**
@@ -94,10 +94,10 @@ class TweetController extends Controller
                 $flashMessage = 'ツイートが編集されました。';
             }
 
-            return redirect()->route('tweets.show')->with('flashMessage', $flashMessage);
+            return redirect()->route("tweets.show")->with("flashMessage", $flashMessage);
 
         } catch (Exception $e) {
-            return redirect()->route('tweets.show')->with('flashMessage', "ツイート編集にエラーが発生しました。");
+            return redirect()->route("tweets.show")->with("flashMessage", "ツイート編集にエラーが発生しました。");
         }
     }
 
@@ -118,18 +118,25 @@ class TweetController extends Controller
     /**
      * もし投稿者と認証中の人間が一致していたら、削除処理を行う
      *
-     * @param [type] $tweetId
-     * @return void
+     * @param string $tweetId
+     *
+     * @return RedirectResponse
      */
-    public function delete($tweetId)
+    public function delete(string $tweetId): RedirectResponse
     {
         try {
+            $flashMessage = "ツイート削除に失敗しました。";
+
             if ($this->isUserPost($tweetId)) {
                 $this->tweet->tweetDelete($tweetId);
+
+                $flashMessage = "ツイート削除に成功しました。";
             }
+
+            return redirect()->route("tweets.show")->with("flashMessage", $flashMessage);
+
         } catch (Exception $e) {
-            return redirect()->route('tweets.show')->with('flashMassage', "ツイート削除に失敗しました。");
+            return redirect()->route("tweets.show")->with("flashMessage", "ツイート削除にエラーが発生しました。");
         }
-        return redirect()->route('tweets.show')->with('flashMessage', 'ツイートが削除されました。');
     }
 }

--- a/twitter/app/Http/Controllers/TweetController.php
+++ b/twitter/app/Http/Controllers/TweetController.php
@@ -7,6 +7,7 @@ use App\Http\Requests\TweetRequest;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
 
 class TweetController extends Controller
 {
@@ -87,18 +88,17 @@ class TweetController extends Controller
     }
 
     /**
-     * 論理削除したツイート以外のデータを取得し、top画面に出力する。
+     * ツイートの投稿idをフォーム（hidden)から取得した。
      *
-     * @param string $tweetId
-     *
-     * @return view
+     * @param Request $request
+     * 
+     * @return RedirectResponse
      */
-    public function delete(string $tweetId): view
+    public function delete(Request $request): RedirectResponse
     {
+        $tweetId = $request->input('tweetId');
         $this->tweet->tweetDelete($tweetId);
 
-        $tweets = Tweet::all();
-
-        return view('top.index', compact('tweets'));
+        return redirect()->route('tweets.show');
     }
 }

--- a/twitter/app/Http/Controllers/TweetController.php
+++ b/twitter/app/Http/Controllers/TweetController.php
@@ -82,12 +82,23 @@ class TweetController extends Controller
      *
      * @return RedirectResponse
      */
-    public function update(TweetRequest $request, string $userId): RedirectResponse
+    public function update(TweetRequest $request, string $tweetId): RedirectResponse
     {
-        $content = $request->input('content');
-        $update = $this->tweet->updateTweet($content, $userId);
+        try {
+            $flashMessage = "ツイート編集に失敗しました。";
 
-        return redirect()->route('tweets.show');
+            if ($this->isUserPost($tweetId)) {
+                $content = $request->input('content');
+                $this->tweet->updateTweet($content, $tweetId);
+
+                $flashMessage = 'ツイートが編集されました。';
+            }
+
+            return redirect()->route('tweets.show')->with('flashMessage', $flashMessage);
+
+        } catch (Exception $e) {
+            return redirect()->route('tweets.show')->with('flashMessage', "ツイート編集にエラーが発生しました。");
+        }
     }
 
     /**

--- a/twitter/app/Http/Controllers/TweetController.php
+++ b/twitter/app/Http/Controllers/TweetController.php
@@ -85,4 +85,20 @@ class TweetController extends Controller
 
         return redirect()->route('tweets.show');
     }
+
+    /**
+     * 論理削除したツイート以外のデータを取得し、top画面に出力する。
+     *
+     * @param string $tweetId
+     *
+     * @return view
+     */
+    public function delete(string $tweetId): view
+    {
+        $this->tweet->tweetDelete($tweetId);
+
+        $tweets = Tweet::all();
+
+        return view('top.index', compact('tweets'));
+    }
 }

--- a/twitter/app/Http/Controllers/UserController.php
+++ b/twitter/app/Http/Controllers/UserController.php
@@ -2,12 +2,13 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
+
 use App\Models\User;
+use App\Http\Requests\UpdateUserRequest;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\RedirectResponse;
-use App\Http\Requests\UpdateUserRequest;
+use Illuminate\Http\Request;
 
 class UserController extends Controller
 {

--- a/twitter/app/Http/Requests/TweetRequest.php
+++ b/twitter/app/Http/Requests/TweetRequest.php
@@ -4,6 +4,7 @@ namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 
+
 class TweetRequest extends FormRequest
 {
     /**
@@ -23,8 +24,9 @@ class TweetRequest extends FormRequest
      */
     public function rules()
     {
+
         return[
-            'content' => 'required|string|max:140',
+            'content' => ['required', 'string', 'max:' . config('validation.TWEET_CONTENT.MAX')],
         ];
     }
     public function messages()
@@ -32,7 +34,7 @@ class TweetRequest extends FormRequest
         return [
             'content.required' => '必ず入力してね',
             'content.string' => '必ず文字列で入力しようね',
-            'content.max' => '140文字以下にせんかい',
+            'content.max' => config('validation.TWEET_CONTENT.MAX')."文字以下にせんかい",
         ];
     }
 }

--- a/twitter/app/Models/Tweet.php
+++ b/twitter/app/Models/Tweet.php
@@ -6,10 +6,12 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\belongsTo;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Tweet extends Model
 {
     use HasFactory;
+    use SoftDeletes;
 
     protected $table = 'tweets';
     protected $fillable = ['content', 'author_id'];
@@ -35,7 +37,7 @@ class Tweet extends Model
     {
         $tweet = new Tweet();
         $tweet->content = $content;
-        $tweet->authorId = $authorId;
+        $tweet->author_id = $authorId;
         $tweet->save();
 
         return $tweet;
@@ -80,5 +82,18 @@ class Tweet extends Model
         $tweet->save();
 
         return $tweet;
+    }
+
+
+    /**
+     * 投稿したツイートのidを見つけて、ツイートを削除する。
+     *
+     * @param string $tweetId
+     *
+     * @return void
+     */
+    public function tweetDelete(string $tweetId)
+    {
+        Tweet::find($tweetId)->delete();
     }
 }

--- a/twitter/app/Models/Tweet.php
+++ b/twitter/app/Models/Tweet.php
@@ -78,21 +78,20 @@ class Tweet extends Model
     public function updateTweet(string $content, string $userId): Tweet
     {
         $tweet = Tweet::find($userId);
-        $content = $tweet->content = $content;
+        $tweet->content = $content;
         $tweet->save();
 
         return $tweet;
     }
 
-
     /**
-     * 投稿したツイートのidを見つけて、ツイートを削除する。
+     * ＄tweetIdに一致したデータを削除する
      *
-     * @param int $tweetId
+     * @param string $tweetId
      *
      * @return void
      */
-    public function tweetDelete(int $tweetId): void
+    public function tweetDelete(string $tweetId): void
     {
         Tweet::find($tweetId)->delete();
     }

--- a/twitter/app/Models/Tweet.php
+++ b/twitter/app/Models/Tweet.php
@@ -46,7 +46,7 @@ class Tweet extends Model
     /**
      * ツイートテーブルから情報を取得する
      *
-     * @return　Collection
+     * @return Collection
      */
     public function getAllTweets(): Collection
     {
@@ -56,7 +56,7 @@ class Tweet extends Model
     }
 
     /**
-     *　Pathパラメータの'/users/{id}'のIDと一致したレコードを取得
+     * Pathパラメータの'/users/{id}'のIDと一致したレコードを取得
      *
      * @param string $userId
      * @return  Tweet
@@ -88,11 +88,11 @@ class Tweet extends Model
     /**
      * 投稿したツイートのidを見つけて、ツイートを削除する。
      *
-     * @param string $tweetId
+     * @param int $tweetId
      *
      * @return void
      */
-    public function tweetDelete(string $tweetId)
+    public function tweetDelete(int $tweetId): void
     {
         Tweet::find($tweetId)->delete();
     }

--- a/twitter/app/Models/User.php
+++ b/twitter/app/Models/User.php
@@ -8,6 +8,7 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Facades\Auth;
 use Laravel\Sanctum\HasApiTokens;
 

--- a/twitter/config/validation.php
+++ b/twitter/config/validation.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'TWEET_CONTENT' => [
+        'MAX' => 140,
+    ]
+];

--- a/twitter/database/migrations/2023_08_16_141735_add_deleted_at_to_tweets_table.php
+++ b/twitter/database/migrations/2023_08_16_141735_add_deleted_at_to_tweets_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('tweets', function (Blueprint $table) {
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('tweets', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/twitter/resources/views/top/index.blade.php
+++ b/twitter/resources/views/top/index.blade.php
@@ -10,6 +10,11 @@
 <div class="container">
     <div class="row justify-content-center">
         <div class="col-md-9">
+            @if (session('flashMessage'))
+            <div class="flash_message">
+                {{ session('flashMessage') }}
+            </div>
+            @endif
             @foreach ($tweets as $tweet)
                 @if($tweet->user)
                 <a href="{{ route('tweet.details', ['id' => $tweet->id]) }}" class="text-reset text-decoration-none">

--- a/twitter/resources/views/tweet/show.blade.php
+++ b/twitter/resources/views/tweet/show.blade.php
@@ -41,7 +41,7 @@
                                                 </ul>
                                             </div>
                                         @endif
-                                    <form action="{{ route('tweet.update', ['id' => $tweet->id]) }}" method="post">
+                                        <form action="{{ route('tweet.update', ['id' => $tweet->id]) }}" method="post">
                                             @method('put')
                                             @csrf
                                             <input type="text" class="form-control input-lg" name="content"
@@ -61,8 +61,7 @@
                             </div>
                         </div>
 
-                        <button type="button" class="btn btn-danger" data-bs-toggle="modal"
-                            data-bs-target="#delete">
+                        <button type="button" class="btn btn-danger" data-bs-toggle="modal" data-bs-target="#delete">
                             削除
                         </button>
                         <!-- Modal -->
@@ -81,10 +80,10 @@
                                             data-bs-dismiss="modal">Close</button>
 
                                         @if ($tweet->author_id == Auth::id())
-                                            <form action="{{ route('tweet.delete') }}" method="post">
+                                            <form class="delete-form"
+                                                action="{{ route('tweet.delete', ['id' => $tweet->id]) }}" method="post">
                                                 @method('put')
                                                 @csrf
-                                                <input type="hidden" name="tweetId" value="{{ $tweet->id }}">
                                                 <button type="submit" class="btn btn-danger">削除</button>
                                             </form>
                                         @else

--- a/twitter/resources/views/tweet/show.blade.php
+++ b/twitter/resources/views/tweet/show.blade.php
@@ -23,7 +23,6 @@
                             data-bs-target="#staticBackdrop">
                             編集
                         </button>
-
                         <!-- Modal -->
                         <div class="modal fade" id="staticBackdrop" data-bs-backdrop="static" data-bs-keyboard="false"
                             tabindex="-1" aria-labelledby="staticBackdropLabel" aria-hidden="true">
@@ -55,6 +54,35 @@
                                             <button type="submit" class="btn btn-primary">編集</button>
                                         @else
                                             <button type="button" class="btn btn-primary" disabled>編集</button>
+                                        @endif
+                                    </div>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+
+                        <button type="button" class="btn btn-danger" data-bs-toggle="modal"
+                            data-bs-target="#delete">
+                            削除
+                        </button>
+                        <!-- Modal -->
+                        <div class="modal fade" id="delete" data-bs-backdrop="static" data-bs-keyboard="false"
+                            tabindex="-1" aria-labelledby="staticBackdropLabel" aria-hidden="true">
+                            <div class="modal-dialog">
+                                <div class="modal-content">
+                                    <div class="modal-header d-block text-center">
+                                        <h5 class="modal-title" id="staticBackdropLabel">削除確認</h5>
+                                    </div>
+                                    <div class="modal-body text-center">
+                                        本当に削除してもいいですか？
+                                    </div>
+                                    <div class="modal-footer">
+                                        <button type="button" class="btn btn-secondary"
+                                            data-bs-dismiss="modal">Close</button>
+                                        @if ($tweet->author_id == Auth::id())
+                                        <a href="{{ route('tweet.delete', ['id' => $tweet->id]) }}" class='btn btn-danger'>削除</a>
+                                        @else
+                                            <button type="button" class="btn btn-danger" disabled>削除</button>
                                         @endif
                                     </div>
                                     </form>

--- a/twitter/resources/views/tweet/show.blade.php
+++ b/twitter/resources/views/tweet/show.blade.php
@@ -79,8 +79,14 @@
                                     <div class="modal-footer">
                                         <button type="button" class="btn btn-secondary"
                                             data-bs-dismiss="modal">Close</button>
+
                                         @if ($tweet->author_id == Auth::id())
-                                        <a href="{{ route('tweet.delete', ['id' => $tweet->id]) }}" class='btn btn-danger'>削除</a>
+                                            <form action="{{ route('tweet.delete') }}" method="post">
+                                                @method('put')
+                                                @csrf
+                                                <input type="hidden" name="tweetId" value="{{ $tweet->id }}">
+                                                <button type="submit" class="btn btn-danger">削除</button>
+                                            </form>
                                         @else
                                             <button type="button" class="btn btn-danger" disabled>削除</button>
                                         @endif

--- a/twitter/resources/views/user/edit.blade.php
+++ b/twitter/resources/views/user/edit.blade.php
@@ -6,22 +6,22 @@
     <div class="row justify-content-center">
         <div class="col-md-6">
             <h3>Edit Profile</h3>
-        </div> 
-    </div>
-    <div class="row justify-content-center">   
-        <div class="col-md-7">
-            @if ($errors->any())  
-                <ul>  
-                    @foreach ($errors->all() as $error)  
-                        <li>{{ $error }}</li>  
-                    @endforeach  
-                </ul>  
-            @endif  
         </div>
-    </div>    
+    </div>
+    <div class="row justify-content-center">
+        <div class="col-md-7">
+            @if ($errors->any())
+                <ul>
+                    @foreach ($errors->all() as $error)
+                        <li>{{ $error }}</li>
+                    @endforeach
+                </ul>
+            @endif
+        </div>
+    </div>
         <div class="row justify-content-center">
             <div class="col-md-8 col-md-offset-1">
-                <form action="{{ route('user.update', [ 'id' => Auth::id()]) }}" method="post">  
+                <form action="{{ route('user.update', [ 'id' => Auth::id()]) }}" method="post">
                     @method('put')
                     @csrf
                     <div class="form-group">

--- a/twitter/routes/web.php
+++ b/twitter/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -44,7 +45,7 @@ Route::group(['prefix' => 'tweet', 'middleware' => 'auth'], function (){
     //ツイートを更新して、ツイート一覧表示に遷移
     Route::put('/{id}/update', [App\Http\Controllers\TweetController::class, 'update'])->name('tweet.update');
     //ツイートを削除する
-    Route::put('/delete', [App\Http\Controllers\TweetController::class, 'delete'])->name('tweet.delete');
+    Route::put('{id}/delete', [App\Http\Controllers\TweetController::class, 'delete'])->name('tweet.delete');
 });
 
 

--- a/twitter/routes/web.php
+++ b/twitter/routes/web.php
@@ -43,6 +43,8 @@ Route::group(['prefix' => 'tweet', 'middleware' => 'auth'], function (){
     Route::get('/{id}/details', [App\Http\Controllers\TweetController::class, 'findByTweetId'])->name('tweet.details');
     //ツイートを更新して、ツイート一覧表示に遷移
     Route::put('/{id}/update', [App\Http\Controllers\TweetController::class, 'update'])->name('tweet.update');
+    //ツイートを削除する
+    Route::get('/{id}/delete', [App\Http\Controllers\TweetController::class, 'delete'])->name('tweet.delete');
 });
 
 

--- a/twitter/routes/web.php
+++ b/twitter/routes/web.php
@@ -44,7 +44,7 @@ Route::group(['prefix' => 'tweet', 'middleware' => 'auth'], function (){
     //ツイートを更新して、ツイート一覧表示に遷移
     Route::put('/{id}/update', [App\Http\Controllers\TweetController::class, 'update'])->name('tweet.update');
     //ツイートを削除する
-    Route::get('/{id}/delete', [App\Http\Controllers\TweetController::class, 'delete'])->name('tweet.delete');
+    Route::put('/delete', [App\Http\Controllers\TweetController::class, 'delete'])->name('tweet.delete');
 });
 
 


### PR DESCRIPTION
# 課題のリンク
ツイートを削除できる

# 改修内容
・ツイート削除ボタンを設置し、押したら、ツイートが論理削除できるように設定
・モデルにツイートの削除機能を設置し、コントローラに論理削除したツイート以外の投稿を取得し、topビューに出力する
(configファイルの中にバリデーションの定義を行い、config()を使ってバリデーション設定を試してみた）

# 検証内容
・dd()を使い、処理の流れを確認しながら作業しました

# 注意事項
- なし