### PR TITLE
add:ツイート投稿にいいねが押せる

### DIFF
--- a/twitter/app/Http/Controllers/TopController.php
+++ b/twitter/app/Http/Controllers/TopController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Tweet;
+use App\Models\Like;
 use App\Http\Requests\SearchRequest;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Contracts\View\View;
@@ -15,12 +16,13 @@ class TopController extends Controller
     /**
      * トップ画面（Twitterの最初の画面）
      *
+     *  @param Like $like
      *  @param Tweet $tweet
      *  @param SearchRequest $request
      *
      * @return view|RedirectResponse
      */
-    public function index(Tweet $tweet, SearchRequest $request): view|RedirectResponse
+    public function index(Like $like, Tweet $tweet, SearchRequest $request): view|RedirectResponse
     {
         try {
             $search = $request->input('search');
@@ -28,6 +30,11 @@ class TopController extends Controller
 
             if(!empty($search)){
                 $tweets = $tweet->searchByQuery($search);
+            }
+
+            foreach ($tweets as $tweet) {
+                $isFavorite = $like->isFavorite($tweet->id);
+                $tweet['isFavorite'] = $isFavorite;
             }
 
             return view('top.index', compact('tweets'));

--- a/twitter/app/Http/Controllers/TopController.php
+++ b/twitter/app/Http/Controllers/TopController.php
@@ -3,7 +3,11 @@
 namespace App\Http\Controllers;
 
 use App\Models\Tweet;
+use App\Models\Like;
+use App\Http\Requests\SearchRequest;
 use Illuminate\Contracts\View\View;
+use Illuminate\Http\RedirectResponse;
+use Exception;
 
 
 class TopController extends Controller
@@ -12,12 +16,31 @@ class TopController extends Controller
     /**
      * トップ画面（Twitterの最初の画面）
      *
-     * @return view
+     * @param Like $like
+     * @param TweetRequest $tweet
+     * @param SearchRequest $request
+     *
+     * @return view|RedirectResponse
      */
-    public function index()
+    public function index(Like $like, Tweet $tweet, SearchRequest $request): View|RedirectResponse
     {
-        $tweets = Tweet::all();
+        try{
+            $tweets = Tweet::all();
 
-        return view('top.index', compact('tweets'));
+            $search = $request->input('search');
+
+            $tweets = $tweet->searchByQuery($search);
+
+            foreach($tweets as $tweet){
+                $isFavorite =$like->isFavorite($tweet->id);
+                $tweet['isFavorite'] = $isFavorite;
+            }
+
+            return view('top.index', compact('tweets'));
+        }catch (Exception $e){
+            Logger($e);
+
+            return redirect()->route('top');
+        }
     }
 }

--- a/twitter/app/Http/Controllers/TweetController.php
+++ b/twitter/app/Http/Controllers/TweetController.php
@@ -3,14 +3,12 @@
 namespace App\Http\Controllers;
 
 use App\Models\Tweet;
+use App\Models\Like;
 use App\Http\Requests\TweetRequest;
-use App\Http\Requests\SearchRequest;
 use Exception;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Http\Request;
-
 
 class TweetController extends Controller
 {
@@ -18,9 +16,11 @@ class TweetController extends Controller
      *Tweetモデルのインスタンスを受け取り、プロパティに代入する
      */
     private $tweet;
-    public function __construct(Tweet $tweet)
+    private $like;
+    public function __construct(Tweet $tweet, Like $like)
     {
         $this->tweet = $tweet;
+        $this->like = $like;
     }
 
     /**
@@ -96,7 +96,6 @@ class TweetController extends Controller
             }
 
             return redirect()->route("tweets.show")->with("flashMessage", $flashMessage);
-
         } catch (Exception $e) {
             return redirect()->route("tweets.show")->with("flashMessage", "ツイート編集にエラーが発生しました。");
         }
@@ -135,30 +134,35 @@ class TweetController extends Controller
             }
 
             return redirect()->route("tweets.show")->with("flashMessage", $flashMessage);
-
         } catch (Exception $e) {
             return redirect()->route("tweets.show")->with("flashMessage", "ツイート削除にエラーが発生しました。");
         }
     }
 
     /**
-     * 投稿内容の検索
+     * いいねを押す
      *
-     * @param SearchRequest $request
+     * @param int $tweetId
      *
-     * @return view|RedirectResponse
+     * @return RedirectResponse
      */
-    public function searchByQuery(SearchRequest $request): view|RedirectResponse
+    public function favorite($tweetId): RedirectResponse
     {
-        try{
-            $search = $request->input('search');
+        $userId = Auth::id();
+        $this->like->favorite($userId, $tweetId);
 
-            $tweets = $this->tweet->searchByQuery($search);
+        return redirect()->route('top');
+    }
 
-            return view('top.index', compact('tweets'));
-        }catch(Exception $e){
-            logger($e);
-            return redirect()->route('top');
-        }
+    /**
+     * いいねを解除する
+     *
+     * @return RedirectResponse
+     */
+    public function unlike($tweetId)
+    {
+        $this->like->unlike($tweetId);
+
+        return redirect()->route('top');
     }
 }

--- a/twitter/app/Http/Controllers/TweetController.php
+++ b/twitter/app/Http/Controllers/TweetController.php
@@ -46,7 +46,7 @@ class TweetController extends Controller
         $content = $request->input("content");
         $this->tweet->create($authorId, $content);
 
-        return redirect()->route("tweets.show");
+        return redirect()->route("tweet.show");
     }
 
     /**
@@ -95,9 +95,9 @@ class TweetController extends Controller
                 $flashMessage = 'ツイートが編集されました。';
             }
 
-            return redirect()->route("tweets.show")->with("flashMessage", $flashMessage);
+            return redirect()->route("tweet.show")->with("flashMessage", $flashMessage);
         } catch (Exception $e) {
-            return redirect()->route("tweets.show")->with("flashMessage", "ツイート編集にエラーが発生しました。");
+            return redirect()->route("tweet.show")->with("flashMessage", "ツイート編集にエラーが発生しました。");
         }
     }
 
@@ -133,9 +133,9 @@ class TweetController extends Controller
                 $flashMessage = "ツイート削除に成功しました。";
             }
 
-            return redirect()->route("tweets.show")->with("flashMessage", $flashMessage);
+            return redirect()->route("tweet.show")->with("flashMessage", $flashMessage);
         } catch (Exception $e) {
-            return redirect()->route("tweets.show")->with("flashMessage", "ツイート削除にエラーが発生しました。");
+            return redirect()->route("tweet.show")->with("flashMessage", "ツイート削除にエラーが発生しました。");
         }
     }
 

--- a/twitter/app/Http/Controllers/TweetController.php
+++ b/twitter/app/Http/Controllers/TweetController.php
@@ -146,7 +146,7 @@ class TweetController extends Controller
      *
      * @return RedirectResponse
      */
-    public function favorite($tweetId): RedirectResponse
+    public function favorite(int $tweetId): RedirectResponse
     {
         $userId = Auth::id();
         $this->like->favorite($userId, $tweetId);
@@ -159,7 +159,7 @@ class TweetController extends Controller
      *
      * @return RedirectResponse
      */
-    public function unlike($tweetId)
+    public function unlike(int $tweetId)
     {
         $this->like->unlike($tweetId);
 

--- a/twitter/app/Http/Controllers/UserController.php
+++ b/twitter/app/Http/Controllers/UserController.php
@@ -155,7 +155,7 @@ class UserController extends Controller
     {
         try{
             $followers = $this->follower->getFollowedUsers();
-            
+
             return view('user.followed', compact('followers'));
         }catch (Exception $e){
 

--- a/twitter/app/Http/Requests/SearchRequest.php
+++ b/twitter/app/Http/Requests/SearchRequest.php
@@ -24,10 +24,15 @@ class SearchRequest extends FormRequest
     public function rules()
     {
         return [
-            'search' => ['max:20']
+            'search' => ['max:' . config('validation.SEARCH_KEYWORD.MAX')]
         ];
     }
 
+    /**
+     * 検索フォームのエラーメッセージ
+     *
+     * @return array
+     */
     public function messages()
     {
         return [

--- a/twitter/app/Models/Like.php
+++ b/twitter/app/Models/Like.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\belongsTo;
+use Illuminate\Support\Facades\Auth;
+
+class Like extends Model
+{
+    use HasFactory;
+
+    protected $table = 'likes';
+    protected $fillable = ['user_id', 'post_id'];
+    /**
+     * リレーション（Userテーブルのidと、user_idを紐づける）
+     *
+     * @return belongsTo
+     */
+    public function users(): belongsTo
+    {
+        return $this->belongsTo(User::class, 'user_id', 'id');
+    }
+
+    /**
+     * リレーション（Tweetテーブルのidとpost_idを紐づける）
+     *
+     * @return belongsTo
+     */
+    public function tweets(): belongsTo
+    {
+        return $this->belongsTo(Tweet::class, 'post_id', 'id');
+    }
+
+    /**
+     * いいねボタンを押したユーザーのidと投稿IDをLikeテーブルに入れる
+     *
+     * @param int $userId
+     * @param int $tweetId
+     *
+     * @return void
+     */
+    public function favorite(int $userId, int $tweetId): void
+    {
+        $like = new Like();
+        $like->user_id = $userId;
+        $like->post_id = $tweetId;
+        $like->save();
+    }
+
+    /**
+     * いいねしているかどうかの判別
+     *
+     * @param int $tweetId
+     *
+     * @return bool
+     */
+    public function isFavorite(int $tweetId): bool
+    {
+        return Like::where([
+            ['user_id', Auth::id()],
+            ['post_id', $tweetId],
+        ])->exists();
+    }
+
+    /**
+     * いいね解除
+     *
+     * @param int $tweetId
+     *
+     * @return void
+     */
+    public function unlike(int $tweetId): void
+    {
+        Like::where([
+            ['user_id', Auth::id()],
+            ['post_id', $tweetId],
+        ])->delete();
+    }
+}

--- a/twitter/app/Models/Tweet.php
+++ b/twitter/app/Models/Tweet.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\belongsTo;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -24,6 +25,16 @@ class Tweet extends Model
     public function user(): belongsTo
     {
         return $this->belongsTo(User::class, 'author_id' , 'id');
+    }
+
+    /**
+     * リレーション（Likeテーブルのpost_idカラムと、idを紐づけている）
+     *
+     * @return hasMany
+     */
+    public function likes(): hasMany
+    {
+        return $this->hasMany(Like::class, 'post_id' , 'id');
     }
 
     /**

--- a/twitter/app/Models/User.php
+++ b/twitter/app/Models/User.php
@@ -116,12 +116,22 @@ class User extends Authenticatable
     }
 
     /**
-     * リレーション（UserテーブルのidとFollowerテーブルのfollowing_idを紐づける。）
+     * リレーション（UserテーブルのidとFollowerテーブルのfollowing_idを紐づける）
      *
      * @return hasMany
      */
     public function followed(): hasMany
     {
         return $this->hasMany(Follower::class, 'following_id', 'id');
+    }
+
+    /**
+     * リレーション（UserテーブルのidとLikeテーブルのuser_idを紐づける）
+     *
+     * @return hasMany
+     */
+    public function likes(): hasMany
+    {
+        return $this->hasMany(Like::class, 'user_id', 'id');
     }
 }

--- a/twitter/config/validation.php
+++ b/twitter/config/validation.php
@@ -5,5 +5,11 @@ declare(strict_types=1);
 return [
     'TWEET_CONTENT' => [
         'MAX' => 140,
+    ],
+    
+    'SEARCH_KEYWORD' => [
+        'MAX' => 20,
     ]
 ];
+
+

--- a/twitter/database/migrations/2023_08_29_150623_create_likes_table.php
+++ b/twitter/database/migrations/2023_08_29_150623_create_likes_table.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('likes', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('user_id');
+            $table->unsignedBigInteger('post_id');
+            $table->timestamps();
+
+            $table->unique([
+                'user_id',
+                'post_id'
+            ]);
+
+            $table->foreign('user_id')
+                    ->references('id')
+                    ->on('users')
+                    ->onDelete('cascade');
+
+            $table->foreign('post_id')
+                    ->references('id')
+                    ->on('tweets')
+                    ->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('likes');
+    }
+};

--- a/twitter/resources/views/layouts/master.blade.php
+++ b/twitter/resources/views/layouts/master.blade.php
@@ -10,6 +10,8 @@
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
         <!-- Fonts -->
         <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap" rel="stylesheet">
+        {{-- Font Awesome --}}
+        <link rel ="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.1.1/css/all.min.css">
     </head>
 <body>
     @include('components.header')

--- a/twitter/resources/views/top/index.blade.php
+++ b/twitter/resources/views/top/index.blade.php
@@ -49,6 +49,24 @@
                                 <p class="mb-0 text-wrap">{{ $tweet->content }}</p>
                             </div>
                         </div>
+                        <div class="card-footer bg-white">
+                            <div class="d-flex justify-content-end">
+                                @if(!$tweet->isFavorite)
+                                    @if($tweet->user_id != Auth::id())
+                                        <form method="POST" action="{{ route('tweet.favorite', ['id' => $tweet->id]) }}"  class="mb-0">
+                                            @csrf
+                                            <button type="submit" class="btn p-0 border-0"><i class="far fa-heart fa-fw"></i></button>
+                                        </form>
+                                    @endif
+                                @else
+                                    <form method="post" action="{{ route('tweet.cancelFavorite', ['id' => $tweet->id]) }}"  class="mb-0">
+                                        @method("delete")
+                                        @csrf
+                                        <button type="submit" class="btn p-0 border-0" ><i class="fa-solid fa-heart fa-fw"></i></button>
+                                    </form>
+                                @endif
+                            </div>
+                        </div>
                     </div>
                 </a>
                 @endif

--- a/twitter/resources/views/top/index.blade.php
+++ b/twitter/resources/views/top/index.blade.php
@@ -52,7 +52,7 @@
                         <div class="card-footer bg-white">
                             <div class="d-flex justify-content-end">
                                 @if(!$tweet->isFavorite)
-                                    @if($tweet->user_id != Auth::id())
+                                    @if($tweet->author_id != Auth::id())
                                         <form method="POST" action="{{ route('tweet.favorite', ['id' => $tweet->id]) }}"  class="mb-0">
                                             @csrf
                                             <button type="submit" class="btn p-0 border-0"><i class="far fa-heart fa-fw"></i></button>

--- a/twitter/resources/views/tweet/create.blade.php
+++ b/twitter/resources/views/tweet/create.blade.php
@@ -9,20 +9,20 @@
                 <div class="card-header text-center">投稿</div>
 
                     <div class="card-body">
-                        <form action="{{ route('tweets.create') }}" method="post">  
+                        <form action="{{ route('tweet.create') }}" method="post">
                             @csrf
                             <div class="form-group form-group-lg">
-                                <div class="row justify-content-center">   
+                                <div class="row justify-content-center">
                                     <div class="col-md-7">
-                                        @if ($errors->any())  
-                                            <ul>  
-                                                @foreach ($errors->all() as $error)  
-                                                    <li>{{ $error }}</li>  
-                                                @endforeach  
-                                            </ul>  
-                                        @endif  
+                                        @if ($errors->any())
+                                            <ul>
+                                                @foreach ($errors->all() as $error)
+                                                    <li>{{ $error }}</li>
+                                                @endforeach
+                                            </ul>
+                                        @endif
                                     </div>
-                                </div>    
+                                </div>
                                 <label for="name">投稿内容</label>
                                 <input type="text" class="form-control input-lg" name="content">
                             </div>

--- a/twitter/resources/views/user/show.blade.php
+++ b/twitter/resources/views/user/show.blade.php
@@ -28,7 +28,7 @@
                 <a href="{{ route('user.showEdit') }}" class='btn btn-light'>編集</a>
                 <!-- Button trigger modal -->
                 <button type="button" class="btn btn-warning" data-bs-toggle="modal" data-bs-target="#exampleModal">削除</button>
-                <a href="{{ route('tweets.showForm') }}" class='btn btn-primary'>投稿</a>
+                <a href="{{ route('tweet.showForm') }}" class='btn btn-primary'>投稿</a>
                 <!-- Modal -->
                 <div class="modal fade" id="exampleModal" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
                 <div class="modal-dialog">

--- a/twitter/routes/web.php
+++ b/twitter/routes/web.php
@@ -57,5 +57,9 @@ Route::group(['prefix' => 'tweet', 'middleware' => 'auth'], function (){
     //ツイートを削除する
     Route::put('{id}/delete', [App\Http\Controllers\TweetController::class, 'delete'])->name('tweet.delete');
     //検索
-    Route::get('/search', [App\Http\Controllers\TweetController::class, 'searchByQuery'])->name('tweet.query');
+    Route::get('/search', [App\Http\Controllers\TopController::class, 'index'])->name('tweet.query');
+    //いいね
+    Route::post('/{id}/favorite',  [App\Http\Controllers\TweetController::class, 'favorite'])->name('tweet.favorite');
+    //いいね解除
+    Route::delete('{id}/cancelFollow', [App\Http\Controllers\TweetController::class, 'unlike'])->name('tweet.cancelFavorite');
 });

--- a/twitter/routes/web.php
+++ b/twitter/routes/web.php
@@ -43,23 +43,23 @@ Route::group(['middleware' => 'auth'], function () {
 });
 
 //ツイート関連
-Route::group(['prefix' => 'tweet', 'middleware' => 'auth'], function (){
+Route::group(['prefix' => 'tweet', 'as' => 'tweet.', 'middleware' => 'auth'], function (){
     //ツイート投稿画面に遷移
-    Route::get('/create', [App\Http\Controllers\TweetController::class, 'showTweetForm'])->name('tweets.showForm');
+    Route::get('/create', [App\Http\Controllers\TweetController::class, 'showTweetForm'])->name('showForm');
     //ツイート投稿
-    Route::post('', [App\Http\Controllers\TweetController::class, 'create'])->name('tweets.create');
+    Route::post('', [App\Http\Controllers\TweetController::class, 'create'])->name('create');
     //ツイート一覧表示
-    Route::get('/show', [App\Http\Controllers\TweetController::class, 'index'])->name('tweets.show');
+    Route::get('/show', [App\Http\Controllers\TweetController::class, 'index'])->name('show');
     //ツイート詳細画面に遷移
-    Route::get('/{id}/details', [App\Http\Controllers\TweetController::class, 'findByTweetId'])->name('tweet.details');
+    Route::get('/{id}/details', [App\Http\Controllers\TweetController::class, 'findByTweetId'])->name('details');
     //ツイートを更新して、ツイート一覧表示に遷移
-    Route::put('/{id}/update', [App\Http\Controllers\TweetController::class, 'update'])->name('tweet.update');
+    Route::put('/{id}/update', [App\Http\Controllers\TweetController::class, 'update'])->name('update');
     //ツイートを削除する
-    Route::put('{id}/delete', [App\Http\Controllers\TweetController::class, 'delete'])->name('tweet.delete');
+    Route::put('{id}/delete', [App\Http\Controllers\TweetController::class, 'delete'])->name('delete');
     //検索
-    Route::get('/search', [App\Http\Controllers\TopController::class, 'index'])->name('tweet.query');
+    Route::get('/search', [App\Http\Controllers\TopController::class, 'index'])->name('query');
     //いいね
-    Route::post('/{id}/favorite',  [App\Http\Controllers\TweetController::class, 'favorite'])->name('tweet.favorite');
+    Route::post('/{id}/favorite',  [App\Http\Controllers\TweetController::class, 'favorite'])->name('favorite');
     //いいね解除
-    Route::delete('{id}/cancelFollow', [App\Http\Controllers\TweetController::class, 'unlike'])->name('tweet.cancelFavorite');
+    Route::delete('{id}/cancelFollow', [App\Http\Controllers\TweetController::class, 'unlike'])->name('cancelFavorite');
 });


### PR DESCRIPTION
# 課題のリンク
いいねが押せる

# 改修内容
・投稿したツイートにいいね（ハートマーク）をつける。
・Likesテーブルにpost_idカラム（投稿したツイートのID）と、user_idカラム（いいねをしたユーザーのID）を作成。
・いいねを押すと、post_idにいいねをされたツイートのIDと、user_idにいいねを押したログインユーザーのIDが入る。
・モデルにいいねをしているかどうか（データベースにデータがあるのか）を判別するメソッドをLikeモデルに作成
・いいねををしているかどうか判別機能をビューに出力し、いいねをしていなかったら、白ハート、していたら赤ハートを作成
・もし、赤ハートを押したら、Likesテーブルにあるpost_idにいいねをされたツイートのIDと、user_idにいいねを押したログインユーザーのIDのレコードを削除する。
（非同期でやろうと思いましたが、とりあえず、同期でやりました。Twitter-clone完成させた後、非同期でも挑戦してみたいと思います。）

# 検証内容
・dd()を使い、処理の流れを確認しながら作業しました