### PR TITLE
add:ツイートにリプライができる

### DIFF
--- a/twitter/app/Http/Controllers/TopController.php
+++ b/twitter/app/Http/Controllers/TopController.php
@@ -24,11 +24,11 @@ class TopController extends Controller
      * @return view|RedirectResponse
      */
     public function index(
-            Like $like,
-            Tweet $tweet,
-            SearchRequest $request
-        ): view | RedirectResponse
-        {
+        Like $like,
+        Tweet $tweet,
+        SearchRequest $request
+    ): view | RedirectResponse
+    {
         try {
             $search = $request->input('search');
             $tweets = Tweet::all();

--- a/twitter/app/Http/Controllers/TweetController.php
+++ b/twitter/app/Http/Controllers/TweetController.php
@@ -23,15 +23,15 @@ class TweetController extends Controller
     private $like;
     private $reply;
     public function __construct(
-            Tweet $tweet,
-            Like $like,
-            Reply $reply
-        )
-        {
-            $this->tweet = $tweet;
-            $this->like = $like;
-            $this->reply = $reply;
-        }
+        Tweet $tweet,
+        Like $like,
+        Reply $reply
+    )
+    {
+        $this->tweet = $tweet;
+        $this->like = $like;
+        $this->reply = $reply;
+    }
 
     /**
      * 投稿ボタンを押したら、投稿画面に遷移

--- a/twitter/app/Http/Controllers/TweetController.php
+++ b/twitter/app/Http/Controllers/TweetController.php
@@ -4,11 +4,14 @@ namespace App\Http\Controllers;
 
 use App\Models\Like;
 use App\Models\Tweet;
+use App\Models\Reply;
 use App\Http\Requests\TweetRequest;
+use App\Http\Requests\ReplyRequest;
 use Exception;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
 
 class TweetController extends Controller
 {
@@ -18,11 +21,17 @@ class TweetController extends Controller
      */
     private $tweet;
     private $like;
-    public function __construct(Tweet $tweet, Like $like)
-    {
-        $this->tweet = $tweet;
-        $this->like = $like;
-    }
+    private $reply;
+    public function __construct(
+            Tweet $tweet,
+            Like $like,
+            Reply $reply
+        )
+        {
+            $this->tweet = $tweet;
+            $this->like = $like;
+            $this->reply = $reply;
+        }
 
     /**
      * 投稿ボタンを押したら、投稿画面に遷移
@@ -139,7 +148,7 @@ class TweetController extends Controller
             return redirect()->route("tweet.show")->with("flashMessage", $flashMessage);
         } catch (Exception $e) {
             logger($e);
-            
+
             return redirect()->route("tweet.show")->with("flashMessage", "ツイート削除にエラーが発生しました。");
         }
     }
@@ -170,4 +179,42 @@ class TweetController extends Controller
 
         return redirect()->route('top');
     }
+
+    /**
+     * リプライ画面に遷移
+     *
+     * @param int $tweetId
+     *
+     * @return View
+     */
+    public function showReplyForm($tweetId): View
+    {
+        $tweet = $this->tweet->getTweetContent($tweetId);
+
+        return view('tweet.createReply', compact('tweet'));
+    }
+
+    /**
+     * リプライ作成
+     *
+     * @param ReplyRequest $request
+     * @param int $tweetId
+     *
+     * @return RedirectResponse
+     */
+    public function createReply(ReplyRequest $request, int $tweetId): RedirectResponse
+    {
+        try{
+            $authorId = Auth::id();
+            $content = $request->input("content");
+            $this->reply->createReply($authorId, $tweetId, $content);
+
+            return redirect()->route('top');
+        }catch(Exception $e){
+            logger($e);
+
+            return redirect()->route('top')->with("flashMessage", "リプライ投稿に失敗しました。");
+        }
+    }
 }
+

--- a/twitter/app/Http/Controllers/TweetController.php
+++ b/twitter/app/Http/Controllers/TweetController.php
@@ -6,7 +6,7 @@ use App\Models\Like;
 use App\Models\Tweet;
 use App\Models\Reply;
 use App\Http\Requests\TweetRequest;
-use App\Http\Requests\ReplyRequest;
+use App\Http\Requests\PostReplyRequest;
 use Exception;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Contracts\View\View;
@@ -202,7 +202,7 @@ class TweetController extends Controller
      *
      * @return RedirectResponse
      */
-    public function createReply(ReplyRequest $request, int $tweetId): RedirectResponse
+    public function createReply(PostReplyRequest $request, int $tweetId): RedirectResponse
     {
         try{
             $authorId = Auth::id();

--- a/twitter/app/Http/Requests/ReplyRequest.php
+++ b/twitter/app/Http/Requests/ReplyRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ReplyRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            'content' => ['required', 'string', 'max:' . config('validation.TWEET_CONTENT.MAX')]
+        ];
+    }
+
+    public function messages()
+    {
+        return[
+            'content.required' => '必ず入力してね',
+            'content.string' => '必ず文字列で入力しようね',
+            'content.max' => config('validation.TWEET_CONTENT.MAX') . "文字以下にせんかい",
+        ];
+    }
+}

--- a/twitter/app/Http/Requests/ReplyRequest.php
+++ b/twitter/app/Http/Requests/ReplyRequest.php
@@ -4,7 +4,7 @@ namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 
-class ReplyRequest extends FormRequest
+class PostReplyRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.

--- a/twitter/app/Models/Reply.php
+++ b/twitter/app/Models/Reply.php
@@ -32,7 +32,16 @@ class Reply extends Model
         return $this->belongsTo(Tweet::class, 'post_id', 'id');
     }
 
-    public function createReply($authorId, $tweetId, $content)
+    /**
+     * リプライを作成
+     *
+     * @param int $authorId
+     * @param int $tweetId
+     * @param string $content
+     *
+     * @return void
+     */
+    public function createReply(int $authorId, int $tweetId, string $content): void
     {
         $this->user_id = $authorId;
         $this->post_id = $tweetId;

--- a/twitter/app/Models/Reply.php
+++ b/twitter/app/Models/Reply.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\belongsTo;
+
+class Reply extends Model
+{
+    use HasFactory;
+
+    protected $table = 'reply';
+    protected $fillable = ['user_id', 'post_id', 'content'];
+    /**
+     * リレーション（Userテーブルのidと、Replyテーブルのuser_idを紐づける）
+     *
+     * @return belongsTo
+     */
+    public function User(): belongsTo
+    {
+        return $this->belongsTo(User::class, 'user_id', 'id');
+    }
+
+    /**
+     * リレーション（Tweetテーブルのidと、Replyテーブルのpost_idを紐づける）
+     *
+     * @return belongsTo
+     */
+    public function Tweet(): belongsTo
+    {
+        return $this->belongsTo(Tweet::class, 'post_id', 'id');
+    }
+
+    public function createReply($authorId, $tweetId, $content)
+    {
+        $this->user_id = $authorId;
+        $this->post_id = $tweetId;
+        $this->content = $content;
+        $this->save();
+    }
+}
+

--- a/twitter/app/Models/Tweet.php
+++ b/twitter/app/Models/Tweet.php
@@ -127,4 +127,28 @@ class Tweet extends Model
 
         return $tweets;
     }
+
+    /**
+     * リレーション（TweetテーブルのidとReplyテーブルのpost_idを紐づける）
+     *
+     * @return hanMany
+     */
+    public function reply(): hasMany
+    {
+        return $this->hasMany(Reply::class, 'post_id', 'id');
+    }
+
+    /**
+     * リプライをするツイートを取得する
+     *
+     * @param int $tweetId
+     *
+     * @return Tweet
+     */
+    public function getTweetContent(int $tweetId): Tweet
+    {
+        return Tweet::findOrFail($tweetId);
+    }
 }
+
+

--- a/twitter/app/Models/User.php
+++ b/twitter/app/Models/User.php
@@ -134,4 +134,14 @@ class User extends Authenticatable
     {
         return $this->hasMany(Like::class, 'user_id', 'id');
     }
+
+    /**
+     * リレーション（UserテーブルのidとReplyテーブルのuser_idを紐づける）
+     *
+     * @return hanMany
+     */
+    public function reply(): hasMany
+    {
+        return $this->hasMany(Reply::class, 'user_id', 'id');
+    }
 }

--- a/twitter/app/Models/User.php
+++ b/twitter/app/Models/User.php
@@ -138,7 +138,7 @@ class User extends Authenticatable
     /**
      * リレーション（UserテーブルのidとReplyテーブルのuser_idを紐づける）
      *
-     * @return hanMany
+     * @return hasMany
      */
     public function reply(): hasMany
     {

--- a/twitter/database/migrations/2023_09_04_171504_create_reply_table.php
+++ b/twitter/database/migrations/2023_09_04_171504_create_reply_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('reply', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('user_id')->comment('ユーザーid');
+            $table->unsignedBigInteger('post_id')->comment('ツイートid');
+            $table->string('content', 140)->comment('コメント内容');
+            $table->timestamps();
+
+            $table->foreign('user_id')
+                ->references('id')
+                ->on('users')
+                ->onDelete('cascade');
+
+            $table->foreign('post_id')
+                ->references('id')
+                ->on('tweets')
+                ->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('reply');
+    }
+};

--- a/twitter/database/migrations/2023_09_04_171504_create_reply_table.php
+++ b/twitter/database/migrations/2023_09_04_171504_create_reply_table.php
@@ -17,7 +17,7 @@ return new class extends Migration
             $table->id();
             $table->unsignedBigInteger('user_id')->comment('ユーザーid');
             $table->unsignedBigInteger('post_id')->comment('ツイートid');
-            $table->string('content', 140)->comment('コメント内容');
+            $table->string('content', config('validation.TWEET_CONTENT.MAX'))->comment('コメント内容');
             $table->timestamps();
 
             $table->foreign('user_id')

--- a/twitter/resources/views/top/index.blade.php
+++ b/twitter/resources/views/top/index.blade.php
@@ -11,9 +11,9 @@
     <div class="row justify-content-center">
         <div class="col-md-9">
             @if (session('flashMessage'))
-            <div class="flash_message">
-                {{ session('flashMessage') }}
-            </div>
+                <div class="flash_message text-center bg-warning">
+                    {{ session('flashMessage') }}
+                </div>
             @endif
             <div class="row justify-content-center">
                 <div class="col-md-7">
@@ -52,7 +52,7 @@
                         <div class="card-footer bg-white">
                             <div class="d-flex justify-content-end">
                                 @if(!$tweet->isFavorite)
-                                    @if($tweet->author_id != Auth::id())
+                                    @if($tweet->author_id !== Auth::id())
                                         <form method="POST" action="{{ route('tweet.favorite', ['id' => $tweet->id]) }}"  class="mb-0">
                                             @csrf
                                             <button type="submit" class="btn p-0 border-0"><i class="far fa-heart fa-fw"></i></button>
@@ -66,6 +66,12 @@
                                         <button type="submit" class="btn p-0 border-0" ><i class="fa-solid fa-heart fa-fw"></i></button>
                                     </form>
                                     <p>{{ $tweet->favoriteCount }}</p>
+                                @endif
+                                @if($tweet->author_id !== Auth::id())
+                                <form method="get" action="{{ route('tweet.showReplyForm', ['id' => $tweet->id]) }}"  class="mb-0">
+                                    @csrf
+                                    <button type="submit" class="btn p-0 mx-2 border-0"><i class="far fa-comment"></i></button>
+                                </form>
                                 @endif
                             </div>
                         </div>

--- a/twitter/resources/views/tweet/createReply.blade.php
+++ b/twitter/resources/views/tweet/createReply.blade.php
@@ -1,0 +1,48 @@
+@extends('layouts.master')
+@section('title','commnet')
+
+@section('content')
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-8">
+            <div class="card p-3 w-100 d-flex">
+                <div class="ml-2 d-flex flex-column">
+                    <p class="mb-0 text-wrap">{{ $tweet->user->name }}</p>
+                    <p class="mb-0 text-wrap">{{ $tweet->content }}</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-8">
+            <div class="card">
+                <div class="card-header text-center">コメント</div>
+                    <div class="card-body">
+                        <form action="{{ route("tweet.createReply", ['id' => $tweet->id]) }}" method="post">
+                            @csrf
+                            <div class="form-group form-group-lg">
+                                <div class="row justify-content-center">
+                                    <div class="col-md-7">
+                                        @if ($errors->any())
+                                            <ul>
+                                                @foreach ($errors->all() as $error)
+                                                    <li>{{ $error }}</li>
+                                                @endforeach
+                                            </ul>
+                                        @endif
+                                    </div>
+                                </div>
+                                <label for="name">コメント</label>
+                                <input type="text" class="form-control input-lg" name="content">
+                            </div>
+                            <button type="submit" class="btn btn-primary float-end">送信</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/twitter/resources/views/tweet/show.blade.php
+++ b/twitter/resources/views/tweet/show.blade.php
@@ -60,7 +60,6 @@
                                 </div>
                             </div>
                         </div>
-
                         <button type="button" class="btn btn-danger" data-bs-toggle="modal" data-bs-target="#delete">
                             削除
                         </button>

--- a/twitter/routes/web.php
+++ b/twitter/routes/web.php
@@ -62,4 +62,8 @@ Route::group(['prefix' => 'tweet', 'as' => 'tweet.', 'middleware' => 'auth'], fu
     Route::post('/{id}/favorite',  [App\Http\Controllers\TweetController::class, 'favorite'])->name('favorite');
     //いいね解除
     Route::delete('{id}/cancelFollow', [App\Http\Controllers\TweetController::class, 'unlike'])->name('cancelFavorite');
+    //リプライ作成ビューに遷移
+    Route::get('{id}/showCreateReply', [App\Http\Controllers\TweetController::class, 'showReplyForm'])->name('showReplyForm');
+    //リプライ作成
+    Route::post('/{id}/createReply', [App\Http\Controllers\TweetController::class, 'createReply'])->name('createReply');
 });

--- a/twitter/routes/web.php
+++ b/twitter/routes/web.php
@@ -61,9 +61,9 @@ Route::group(['prefix' => 'tweet', 'as' => 'tweet.', 'middleware' => 'auth'], fu
     //いいね
     Route::post('/{id}/favorite',  [App\Http\Controllers\TweetController::class, 'favorite'])->name('favorite');
     //いいね解除
-    Route::delete('{id}/cancelFollow', [App\Http\Controllers\TweetController::class, 'unlike'])->name('cancelFavorite');
+    Route::delete('/{id}/cancelFollow', [App\Http\Controllers\TweetController::class, 'unlike'])->name('cancelFavorite');
     //リプライ作成ビューに遷移
-    Route::get('{id}/showCreateReply', [App\Http\Controllers\TweetController::class, 'showReplyForm'])->name('showReplyForm');
+    Route::get('/{id}/showCreateReply', [App\Http\Controllers\TweetController::class, 'showReplyForm'])->name('showReplyForm');
     //リプライ作成
     Route::post('/{id}/createReply', [App\Http\Controllers\TweetController::class, 'createReply'])->name('createReply');
 });


### PR DESCRIPTION
# 課題のリンク
ツイートにリプライができる

# 改修内容
・コメントボタンを追加し、ボタンをクリックしたら、リプライ作成ビューに遷移
→リプライ画面にリプライをする投稿を出力できるように、ツイートIDを取得し、ルーティングに渡す。
・replyテーブルを作成し、送信ボタンを押したら、replyテーブルにツイートID、ユーザーID、投稿内容を入れることができるようにする。
・リプライフォームにバリデーションを設置する。
# 検証内容
・dd()を使い、処理の流れを確認しながら作業しました