### PR TITLE
add:リプライ一覧表示

### DIFF
--- a/twitter/app/Http/Controllers/TweetController.php
+++ b/twitter/app/Http/Controllers/TweetController.php
@@ -81,8 +81,9 @@ class TweetController extends Controller
     public function findByTweetId(string $userId): view
     {
         $tweet = $this->tweet->getTweet($userId);
+        $replies = $this->reply->getAllReply();
 
-        return view("tweet.show", compact('tweet'));
+        return view("tweet.show", compact('tweet', 'replies'));
     }
 
     /**
@@ -204,17 +205,16 @@ class TweetController extends Controller
      */
     public function createReply(PostReplyRequest $request, int $tweetId): RedirectResponse
     {
-        try{
+        try {
             $authorId = Auth::id();
             $content = $request->input("content");
             $this->reply->createReply($authorId, $tweetId, $content);
 
             return redirect()->route('top');
-        }catch(Exception $e){
+        } catch (Exception $e) {
             logger($e);
 
             return redirect()->route('top')->with("flashMessage", "リプライ投稿に失敗しました。");
         }
     }
 }
-

--- a/twitter/app/Http/Requests/PostReplyRequest.php
+++ b/twitter/app/Http/Requests/PostReplyRequest.php
@@ -21,16 +21,21 @@ class PostReplyRequest extends FormRequest
      *
      * @return array<string, mixed>
      */
-    public function rules()
+    public function rules(): array
     {
         return [
             'content' => ['required', 'string', 'max:' . config('validation.TWEET_CONTENT.MAX')]
         ];
     }
 
-    public function messages()
+    /**
+     * エラーメッセージ
+     *
+     * @return array
+     */
+    public function messages(): array
     {
-        return[
+        return [
             'content.required' => '必ず入力してね',
             'content.string' => '必ず文字列で入力しようね',
             'content.max' => config('validation.TWEET_CONTENT.MAX') . "文字以下にせんかい",

--- a/twitter/app/Models/Reply.php
+++ b/twitter/app/Models/Reply.php
@@ -5,6 +5,8 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\belongsTo;
+use Illuminate\Database\Eloquent\Collection;
+
 
 class Reply extends Model
 {
@@ -47,6 +49,16 @@ class Reply extends Model
         $this->post_id = $tweetId;
         $this->content = $content;
         $this->save();
+    }
+
+    /**
+     * リプライのデータを全て取得
+     *
+     * @return Collection
+     */
+    public function getAllReply(): Collection
+    {
+        return Reply::all();
     }
 }
 

--- a/twitter/resources/views/tweet/show.blade.php
+++ b/twitter/resources/views/tweet/show.blade.php
@@ -95,6 +95,18 @@
                         </div>
                     </div>
                 </div>
+                @foreach($replies as $reply)
+                    @if($tweet->id === $reply->post_id)
+                        <div class="card mb-2 rounded-pill">
+                            <div class="card-body p-3 w-100 d-flex">
+                                <div class="ml-10 d-flex flex-column">
+                                    <p>{{ $reply->user->name }}</p>
+                                    <p>{{ $reply->content }}</p>
+                                </div>
+                            </div>
+                        </div>
+                    @endif
+                @endforeach
             </div>
         </div>
     </div>


### PR DESCRIPTION
# 課題のリンク
ツイートにリプライができる

# 改修内容
・リプライ表示メソッドをモデルに作成（全てのリプライデータを取ってくる）
・トップ画面にリプライを表示するため、リプライモデルにある、リプライ取得メソッドをtweetコントローラのfindByTweetIdメソッドへ。（compactでリプライの変数を渡してあげる）
・foreacch()でリプライの配列を渡してあげて、そこから、if（$tweet→id === $reply→post_id)となったリプライを投稿の下にリプライを表示させる

# 検証内容
・dd()を使い、処理の流れを確認しながら作業しました